### PR TITLE
Add RedisSet class for managing Redis sets

### DIFF
--- a/redisify/__init__.py
+++ b/redisify/__init__.py
@@ -1,3 +1,4 @@
+from redisify.structures.set import RedisSet
 from redisify.structures.list import RedisList
 from redisify.structures.dict import RedisDict
 from redisify.structures.queue import RedisQueue
@@ -12,4 +13,5 @@ __all__ = [
     "RedisLock",
     "RedisSemaphore",
     "RedisLimiter",
+    "RedisSet",
 ]

--- a/redisify/structures/set.py
+++ b/redisify/structures/set.py
@@ -1,0 +1,131 @@
+import uuid
+
+from redis.asyncio import Redis
+from redisify.serializer import Serializer
+
+
+class RedisSet:
+
+    def __init__(self, redis: Redis, name: str = None, serializer: Serializer = None):
+        self.redis = redis
+        _name = name or str(uuid.uuid4())
+        self.name = f"redisify:set:{_name}"
+        self.serializer = serializer or Serializer()
+
+    async def add(self, item):
+        await self.redis.sadd(self.name, self.serializer.serialize(item))
+
+    async def remove(self, item):
+        removed = await self.redis.srem(self.name, self.serializer.serialize(item))
+        if not removed:
+            raise KeyError(item)
+
+    async def discard(self, item):
+        await self.redis.srem(self.name, self.serializer.serialize(item))
+
+    async def pop(self):
+        val = await self.redis.spop(self.name)
+        if val is None:
+            raise KeyError('pop from an empty set')
+        return self.serializer.deserialize(val)
+
+    async def clear(self):
+        await self.redis.delete(self.name)
+
+    async def __contains__(self, item):
+        return await self.redis.sismember(self.name, self.serializer.serialize(item))
+
+    async def __len__(self):
+        return await self.redis.scard(self.name)
+
+    async def to_set(self):
+        members = await self.redis.smembers(self.name)
+        return set(self.serializer.deserialize(m) for m in members)
+
+    def __aiter__(self):
+        self._aiter_members = None
+        self._aiter_index = 0
+        return self
+
+    async def __anext__(self):
+        if self._aiter_members is None:
+            self._aiter_members = list(await self.to_set())
+        if self._aiter_index >= len(self._aiter_members):
+            raise StopAsyncIteration
+        item = self._aiter_members[self._aiter_index]
+        self._aiter_index += 1
+        return item
+
+    async def update(self, *others):
+        pipe = self.redis.pipeline()
+        for other in others:
+            if isinstance(other, RedisSet):
+                other = await other.to_set()
+            for item in other:
+                pipe.sadd(self.name, self.serializer.serialize(item))
+        await pipe.execute()
+
+    async def difference(self, *others):
+        sets = [self.name]
+        for other in others:
+            if isinstance(other, RedisSet):
+                sets.append(other.name)
+            else:
+                # create a temp set for non-RedisSet
+                temp_name = f"redisify:temp:{uuid.uuid4()}"
+                await self.redis.sadd(temp_name, *[self.serializer.serialize(i) for i in other])
+                sets.append(temp_name)
+        diff = await self.redis.sdiff(*sets)
+        # cleanup temp sets
+        for name in sets[1:]:
+            if name.startswith("redisify:temp:"):
+                await self.redis.delete(name)
+        return set(self.serializer.deserialize(m) for m in diff)
+
+    async def union(self, *others):
+        sets = [self.name]
+        for other in others:
+            if isinstance(other, RedisSet):
+                sets.append(other.name)
+            else:
+                temp_name = f"redisify:temp:{uuid.uuid4()}"
+                await self.redis.sadd(temp_name, *[self.serializer.serialize(i) for i in other])
+                sets.append(temp_name)
+        union = await self.redis.sunion(*sets)
+        for name in sets[1:]:
+            if name.startswith("redisify:temp:"):
+                await self.redis.delete(name)
+        return set(self.serializer.deserialize(m) for m in union)
+
+    async def intersection(self, *others):
+        sets = [self.name]
+        for other in others:
+            if isinstance(other, RedisSet):
+                sets.append(other.name)
+            else:
+                temp_name = f"redisify:temp:{uuid.uuid4()}"
+                await self.redis.sadd(temp_name, *[self.serializer.serialize(i) for i in other])
+                sets.append(temp_name)
+        inter = await self.redis.sinter(*sets)
+        for name in sets[1:]:
+            if name.startswith("redisify:temp:"):
+                await self.redis.delete(name)
+        return set(self.serializer.deserialize(m) for m in inter)
+
+    async def issubset(self, other):
+        if isinstance(other, RedisSet):
+            other = await other.to_set()
+        this_set = await self.to_set()
+        return this_set.issubset(other)
+
+    async def issuperset(self, other):
+        if isinstance(other, RedisSet):
+            other = await other.to_set()
+        this_set = await self.to_set()
+        return this_set.issuperset(other)
+
+    async def isdisjoint(self, other):
+        if isinstance(other, RedisSet):
+            other = await other.to_set()
+        this_set = await self.to_set()
+        return this_set.isdisjoint(other)

--- a/tests/test_redis_set.py
+++ b/tests/test_redis_set.py
@@ -1,0 +1,72 @@
+from redis.asyncio import Redis
+from redisify import RedisSet
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_redis_set_basic():
+    redis = Redis(decode_responses=True)
+    rset = RedisSet(redis, "test:set")
+    await rset.clear()
+
+    await rset.add("a")
+    await rset.add("b")
+    await rset.add("c")
+    assert await rset.__len__() == 3
+    assert await rset.__contains__("a")
+    assert not await rset.__contains__("x")
+
+    s = await rset.to_set()
+    assert s == {"a", "b", "c"}
+
+    await rset.remove("b")
+    assert await rset.to_set() == {"a", "c"}
+
+    await rset.discard("x")  # should not raise
+    await rset.discard("a")
+    assert await rset.to_set() == {"c"}
+
+    popped = await rset.pop()
+    assert popped == "c"
+    assert await rset.__len__() == 0
+
+    await rset.clear()
+    assert await rset.__len__() == 0
+
+
+@pytest.mark.asyncio
+async def test_redis_set_update_and_setops():
+    redis = Redis(decode_responses=True)
+    s1 = RedisSet(redis, "test:set1")
+    s2 = RedisSet(redis, "test:set2")
+    await s1.clear()
+    await s2.clear()
+    await s1.update([1, 2, 3])
+    await s2.update([3, 4, 5])
+
+    assert await s1.to_set() == {1, 2, 3}
+    assert await s2.to_set() == {3, 4, 5}
+
+    diff = await s1.difference(s2)
+    assert diff == {1, 2}
+    union = await s1.union(s2)
+    assert union == {1, 2, 3, 4, 5}
+    inter = await s1.intersection(s2)
+    assert inter == {3}
+
+    assert await s1.issubset([1, 2, 3, 4])
+    assert await s1.issuperset([1, 2])
+    assert await s1.isdisjoint([4, 5, 6])
+
+
+@pytest.mark.asyncio
+async def test_redis_set_async_iter():
+    redis = Redis(decode_responses=True)
+    rset = RedisSet(redis, "test:set:iter")
+    await rset.clear()
+    await rset.update(["x", "y", "z"])
+    items = set()
+    async for item in rset:
+        items.add(item)
+    assert items == {"x", "y", "z"}
+    await rset.clear()


### PR DESCRIPTION
- Introduced the `RedisSet` class to provide set operations with Redis, including methods for adding, removing, and performing set operations like union, intersection, and difference.
- Implemented asynchronous iteration support and methods for checking subset, superset, and disjoint relationships.
- Updated `__init__.py` to include `RedisSet` in the public API.
- Added unit tests for basic functionality and set operations to ensure reliability.