### PR TITLE
Add value method to RedisSemaphore and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ async def api_call():
 # Run multiple concurrent calls
 tasks = [api_call() for _ in range(10)]
 await asyncio.gather(*tasks)
+
+# Check current semaphore value
+current_value = await semaphore.value()
+print(f"Currently {current_value} semaphores are acquired")
 ```
 
 ### RedisLimiter

--- a/redisify/distributed/semaphore.py
+++ b/redisify/distributed/semaphore.py
@@ -55,6 +55,10 @@ class RedisSemaphore:
     async def release(self):
         await self.redis.rpop(self.name)
 
+    async def value(self) -> int:
+        """Get the current number of acquired semaphores."""
+        return await self.redis.llen(self.name)
+
     async def __aenter__(self):
         await self.acquire()
         return self

--- a/tests/test_redis_semaphore.py
+++ b/tests/test_redis_semaphore.py
@@ -36,3 +36,64 @@ async def test_redis_semaphore_async_with():
 
     # After context, should be released (no error means pass)
     assert True
+
+
+@pytest.mark.asyncio
+async def test_redis_semaphore_value():
+    redis = Redis(decode_responses=True)
+    await redis.delete("redisify:semaphore:test:semaphore:value")  # clear before test
+
+    sem1 = RedisSemaphore(redis, 3, "test:semaphore:value")
+    sem2 = RedisSemaphore(redis, 3, "test:semaphore:value")
+    sem3 = RedisSemaphore(redis, 3, "test:semaphore:value")
+
+    # Initially, no semaphores are acquired
+    assert await sem1.value() == 0
+
+    # Acquire first semaphore
+    await sem1.acquire()
+    assert await sem1.value() == 1
+    assert await sem2.value() == 1  # All instances share the same semaphore
+
+    # Acquire second semaphore
+    await sem2.acquire()
+    assert await sem1.value() == 2
+    assert await sem2.value() == 2
+    assert await sem3.value() == 2
+
+    # Acquire third semaphore
+    await sem3.acquire()
+    assert await sem1.value() == 3
+    assert await sem2.value() == 3
+    assert await sem3.value() == 3
+
+    # Release one semaphore
+    await sem1.release()
+    assert await sem1.value() == 2
+    assert await sem2.value() == 2
+    assert await sem3.value() == 2
+
+    # Release remaining semaphores
+    await sem2.release()
+    await sem3.release()
+    assert await sem1.value() == 0
+    assert await sem2.value() == 0
+    assert await sem3.value() == 0
+
+
+@pytest.mark.asyncio
+async def test_redis_semaphore_value_with_context_manager():
+    redis = Redis(decode_responses=True)
+    await redis.delete("redisify:semaphore:test:semaphore:value:context")  # clear before test
+
+    sem = RedisSemaphore(redis, 2, "test:semaphore:value:context")
+
+    # Initially, no semaphores are acquired
+    assert await sem.value() == 0
+
+    # Use context manager
+    async with sem:
+        assert await sem.value() == 1
+
+    # After context, semaphore should be released
+    assert await sem.value() == 0


### PR DESCRIPTION
- Introduced an asynchronous `value` method in the RedisSemaphore class to retrieve the current number of acquired semaphores.
- Updated README.md to include an example of checking the current semaphore value after multiple concurrent API calls.
- Added unit tests for the new `value` method to ensure correct functionality and context management.