### PR TITLE
Refactor serializer to use dill for object serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = ["redis"]
+dependencies = ["redis", "dill"]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0", "pytest-asyncio>=0.20.0"]

--- a/redisify/serializer.py
+++ b/redisify/serializer.py
@@ -1,65 +1,49 @@
-import json
-import pickle
+import dill
 import base64
-import importlib
-from datetime import datetime
-from uuid import UUID
 from typing import Any
 
 
 class Serializer:
+    """Simple and universal serializer using dill for all Python objects"""
 
-    def __init__(self, use_pickle_fallback: bool = True):
-        self.use_pickle_fallback = use_pickle_fallback
+    def __init__(self):
+        """Initialize the serializer (no parameters needed with dill)"""
+        pass
 
     def serialize(self, obj: Any) -> str:
+        """
+        Serialize any Python object to a string using dill
+        
+        Args:
+            obj: Any Python object to serialize
+            
+        Returns:
+            Base64 encoded string representation of the object
+            
+        Raises:
+            TypeError: If serialization fails
+        """
         try:
-            # Detect Pydantic v2 or v1
-            if hasattr(obj, "model_dump"):
-                return json.dumps({
-                    "__pydantic_model__": f"{obj.__class__.__module__}.{obj.__class__.__name__}",
-                    "data": obj.model_dump(),
-                })
-            elif hasattr(obj, "dict"):
-                return json.dumps({
-                    "__pydantic_model__": f"{obj.__class__.__module__}.{obj.__class__.__name__}",
-                    "data": obj.dict(),
-                })
-
-            return json.dumps(obj, default=self._default_json_encoder)
-        except (TypeError, ValueError):
-            if self.use_pickle_fallback:
-                try:
-                    pickled = pickle.dumps(obj)
-                    b64 = base64.b64encode(pickled).decode("utf-8")
-                    return json.dumps({"__format__": "pickle", "data": b64})
-                except Exception as e:
-                    raise TypeError(f"Pickle fallback failed: {e}")
-            raise
+            pickled = dill.dumps(obj)
+            return base64.b64encode(pickled).decode('utf-8')
+        except Exception as e:
+            raise TypeError(f"Serialization failed: {e}")
 
     def deserialize(self, s: str) -> Any:
+        """
+        Deserialize a string back to the original Python object using dill
+        
+        Args:
+            s: Base64 encoded string from serialize()
+            
+        Returns:
+            The original Python object with all its type information preserved
+            
+        Raises:
+            ValueError: If deserialization fails
+        """
         try:
-            obj = json.loads(s)
-
-            if isinstance(obj, dict):
-                # Pydantic model auto-import
-                if "__pydantic_model__" in obj and "data" in obj:
-                    module_path, class_name = obj["__pydantic_model__"].rsplit(".", 1)
-                    module = importlib.import_module(module_path)
-                    cls = getattr(module, class_name)
-                    return cls(**obj["data"])
-
-                # Pickle fallback
-                if obj.get("__format__") == "pickle":
-                    return pickle.loads(base64.b64decode(obj["data"]))
-
-            return obj
+            pickled = base64.b64decode(s.encode('utf-8'))
+            return dill.loads(pickled)
         except Exception as e:
-            raise ValueError(f"Failed to deserialize: {e}")
-
-    def _default_json_encoder(self, obj):
-        if isinstance(obj, (datetime, UUID)):
-            return str(obj)
-        if isinstance(obj, set):
-            return list(obj)
-        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+            raise ValueError(f"Deserialization failed: {e}")


### PR DESCRIPTION
- Updated the Serializer class to utilize dill for serializing and deserializing Python objects, enhancing compatibility with a wider range of object types.
- Removed the previous JSON and pickle fallback mechanisms, simplifying the code.
- Updated the pyproject.toml to include dill as a dependency.