### PR TITLE
Refactor Redis structures to use namespace prefixes for key management

### DIFF
--- a/redisify/distributed/limiter.py
+++ b/redisify/distributed/limiter.py
@@ -18,13 +18,15 @@ class RedisLimiter:
     when tokens are available.
     
     Attributes:
-        redis: The Redis client instance
+        namespace: The namespace prefix for Redis keys
         id: The Redis key id for this limiter
         rate_limit: Maximum number of tokens (bucket capacity)
         time_period: Time period in seconds to fully refill the bucket
         refill_rate: Rate at which tokens are refilled (tokens per second)
         sleep: Sleep duration between acquisition attempts
     """
+
+    namespace: str = "redisify:limiter"
 
     def __init__(
         self,
@@ -44,7 +46,7 @@ class RedisLimiter:
         """
         self.redis = get_redis()
         _id = id or str(uuid.uuid4())
-        self.id = f"redisify:limiter:{_id}"
+        self.id = f"{self.namespace}:{_id}"
         self.rate_limit = rate_limit
         self.time_period = time_period
         self.refill_rate = rate_limit / time_period  # tokens per second

--- a/redisify/distributed/lock.py
+++ b/redisify/distributed/lock.py
@@ -16,10 +16,13 @@ class RedisLock:
     the lock can release it, preventing accidental releases by other processes.
     
     Attributes:
+        namespace: The namespace prefix for Redis keys
         id: The Redis key id for this lock
         token: Unique identifier for this lock instance
         sleep: Sleep duration between acquisition attempts
     """
+
+    namespace: str = "redisify:lock"
 
     def __init__(self, id: str = None, sleep: float = 0.1):
         """
@@ -31,7 +34,7 @@ class RedisLock:
         """
         self.redis = get_redis()
         _id = id or str(uuid.uuid4())
-        self.id = f"redisify:lock:{_id}"
+        self.id = f"{self.namespace}:{_id}"
         self.token = str(uuid.uuid4())
         self.sleep = sleep
 

--- a/redisify/distributed/semaphore.py
+++ b/redisify/distributed/semaphore.py
@@ -44,12 +44,15 @@ class RedisSemaphore:
     acquisition when the count is below the specified limit.
     
     Attributes:
+        namespace: The namespace prefix for Redis keys
         id: The Redis key id for this semaphore
         limit: Maximum number of permits that can be acquired
         sleep: Sleep duration between acquisition attempts
         _script_can_acquire: Registered Lua script for checking availability
         _script_acquire: Registered Lua script for acquiring permits
     """
+
+    namespace: str = "redisify:semaphore"
 
     def __init__(self, id: str, limit: int, sleep: float = 0.1):
         """
@@ -62,7 +65,7 @@ class RedisSemaphore:
         """
         self.redis = get_redis()
         _id = id or str(uuid.uuid4())
-        self.id = f"redisify:semaphore:{_id}"
+        self.id = f"{self.namespace}:{_id}"
         self.limit = limit
         self.sleep = sleep
 

--- a/redisify/structures/dict.py
+++ b/redisify/structures/dict.py
@@ -19,9 +19,12 @@ class RedisDict:
     and values.
     
     Attributes:
+        namespace: The namespace prefix for Redis keys
         id: The Redis key id for this dictionary
         serializer: Serializer instance for object serialization
     """
+
+    namespace: str = "redisify:dict"
 
     def __init__(self, id: str = None, serializer: Serializer = None):
         """
@@ -33,7 +36,7 @@ class RedisDict:
         """
         self.redis = get_redis()
         _id = id or str(uuid.uuid4())
-        self.id = f"redisify:dict:{_id}"
+        self.id = f"{self.namespace}:{_id}"
         self.serializer = serializer or Serializer()
 
     async def __getitem__(self, key):

--- a/redisify/structures/queue.py
+++ b/redisify/structures/queue.py
@@ -20,12 +20,14 @@ class RedisQueue:
     to block when the queue is full.
     
     Attributes:
-        redis: The Redis client instance
+        namespace: The namespace prefix for Redis keys
         id: The Redis key id for this queue
         serializer: Serializer instance for object serialization
         maxsize: Maximum number of items in the queue (None for unlimited)
         sleep: Sleep duration between blocking operations
     """
+
+    namespace: str = "redisify:queue"
 
     def __init__(
         self,
@@ -45,7 +47,7 @@ class RedisQueue:
         """
         self.redis = get_redis()
         _id = id or str(uuid.uuid4())
-        self.id = f"redisify:queue:{_id}"
+        self.id = f"{self.namespace}:{_id}"
         self.serializer = serializer or Serializer()
         self.size = size
         self.sleep = sleep


### PR DESCRIPTION
- Updated RedisLimiter, RedisLock, RedisSemaphore, RedisDict, RedisList, RedisQueue, and RedisSet to introduce a `namespace` attribute for key naming consistency.
- Changed key generation to utilize the namespace prefix, enhancing clarity and organization in Redis key management across all structures.
- Improved documentation to reflect the new namespace attribute, ensuring better understanding of key usage in the Redis context.